### PR TITLE
Removed consistency check from redo log processing.

### DIFF
--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2205,15 +2205,11 @@ files_checked:
     /* We have gone through the redo log, now check if all the
     tablespaces were found and recovered. */
 
-    if (srv_force_recovery == 0 && fil_check_missing_tablespaces()) {
-      ib::error(ER_IB_MSG_1139);
-
-      /* Set the abort flag to true. */
-      auto p = recv_recovery_from_checkpoint_finish(*log_sys, true);
-
-      ut_a(p == nullptr);
-
-      return (srv_init_abort(DB_ERROR));
+    if(srv_force_recovery == 0 && fil_check_missing_tablespaces()) {
+      // Missing tablespaces in the redo log are a valid possibility
+      // with partial backups.
+      // But keep them in the output for visibility
+      ib::warn(ER_IB_MSG_1139);
     }
 
     /* We have successfully recovered from the redo log. The

--- a/storage/innobase/xtrabackup/test/t/ib_databases.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_databases.sh
@@ -41,6 +41,11 @@ start_server
 
 OUT=`run_cmd $MYSQL $MYSQL_ARGS -e "USE test; SHOW TABLES; USE test1; SHOW TABLES;" | tr -d '\n'`
 
-if [ $OUT != "Tables_in_testabcTables_in_test1bc" ] ; then
+if [ $OUT != "Tables_in_testabcTables_in_test1abc" ] ; then
 	die "Backed up tables set doesn't match filter"
 fi
+
+run_cmd $MYSQL $MYSQL_ARGS -e "USE test; SELECT * FROM a;"
+run_cmd_expect_failure $MYSQL $MYSQL_ARGS -e "USE test1; SELECT * FROM a;"
+run_cmd $MYSQL $MYSQL_ARGS -e "USE test1; DROP TABLE a;"
+

--- a/storage/innobase/xtrabackup/test/t/ib_databases_file.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_databases_file.sh
@@ -51,6 +51,10 @@ start_server
 
 OUT=`run_cmd $MYSQL $MYSQL_ARGS -e "USE test; SHOW TABLES; USE test1; SHOW TABLES;" | tr -d '\n'`
 
-if [ $OUT != "Tables_in_testabcTables_in_test1bc" ] ; then
+if [ $OUT != "Tables_in_testabcTables_in_test1abc" ] ; then
 	die "Backed up tables set doesn't match filter"
 fi
+
+run_cmd $MYSQL $MYSQL_ARGS -e "USE test; SELECT * FROM a;"
+run_cmd_expect_failure $MYSQL $MYSQL_ARGS -e "USE test1; SELECT * FROM a;"
+run_cmd $MYSQL $MYSQL_ARGS -e "USE test1; DROP TABLE a;"


### PR DESCRIPTION
This caused an error when the redo log references an unknown tablespace,
breaking partial backups.

With this change, we keep the diagnostic message about this in the logs,
but do not fail the prepare operation.

The testcases also had to be adjusted, as MySQL 8.0 stores the table list
in the mysql database, which we restore in its original point. The tables
missing from the backup are still visible, but can't be used now.