### PR TITLE
Remote tablespaces

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -709,64 +709,12 @@ ELSE()
   SET(MYSQLD_SOURCE main.cc)
 ENDIF()
 
-MYSQL_ADD_EXECUTABLE(mysqld
-  ${MYSQLD_SOURCE} DESTINATION ${INSTALL_SBINDIR} COMPONENT Server)
-
 OPTION(DEBUG_EXTNAME "Build server as mysqld-debug (debug builds only)" OFF)
 MARK_AS_ADVANCED(DEBUG_EXTNAME)
 
 IF(DEBUG_EXTNAME)
   SET_TARGET_PROPERTIES(mysqld PROPERTIES DEBUG_OUTPUT_NAME "mysqld-debug")
 ENDIF()
-
-IF(APPLE) 
-  # Add CoreServices framework since some dloadable plugins may need it 
-  FIND_LIBRARY(CORESERVICES NAMES CoreServices) 
-  IF(CORESERVICES) 
-    TARGET_LINK_LIBRARIES(mysqld ${CORESERVICES}) 
-  ENDIF() 
-  IF(NOT BUILD_IS_SINGLE_CONFIG)
-    ADD_COMPILE_FLAGS(mysqld.cc COMPILE_FLAGS -DAPPLE_XCODE)
-  ENDIF()
-ENDIF() 
-
-IF(NOT DISABLE_SHARED)
-  SET_TARGET_PROPERTIES(mysqld PROPERTIES ENABLE_EXPORTS TRUE)
-  GET_TARGET_PROPERTY(mysqld_link_flags mysqld LINK_FLAGS)
-  IF(NOT mysqld_link_flags)
-    SET(mysqld_link_flags)
-  ENDIF()
-  IF(MSVC)
-    # Set module definition file.
-    SET_TARGET_PROPERTIES(mysqld
-      PROPERTIES LINK_FLAGS "${mysqld_link_flags} /DEF:${CMAKE_CURRENT_BINARY_DIR}/mysqld.def")
-
-    SET(_PLATFORM  x64)
-    ADD_CUSTOM_COMMAND(TARGET mysqld PRE_LINK
-      COMMAND echo ${_PLATFORM} && cscript ARGS //nologo ${PROJECT_SOURCE_DIR}/win/create_def_file.js
-      ${_PLATFORM}
-      "$<TARGET_FILE:binlog>"
-      "$<TARGET_FILE:binlogevents_static>"
-      "$<TARGET_FILE:dbug>"
-      "$<TARGET_FILE:mysys>"
-      "$<TARGET_FILE:mysys_ssl>"
-      "$<TARGET_FILE:slave>"
-      "$<TARGET_FILE:sql_main>"
-      "$<TARGET_FILE:strings>"
-      "$<TARGET_FILE:vio>"
-      > mysqld.def
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-    ADD_DEPENDENCIES(sql_main GenError)
-  ENDIF()
-ENDIF()
-
-SET_TARGET_PROPERTIES(mysqld PROPERTIES ENABLE_EXPORTS TRUE) 
-TARGET_LINK_LIBRARIES(mysqld
-  sql_main sql_gis binlog rpl master slave sql_main sql_dd sql_gis mysys mysys_ssl
-  binlogevents_static ${ICU_LIBRARIES})
-
-# Remove transitive link dependencies when linking plugins
-SET_TARGET_PROPERTIES(mysqld PROPERTIES INTERFACE_LINK_LIBRARIES "")
 
 SET(WITH_MYSQLD_LDFLAGS "" CACHE STRING "Additional linker flags for mysqld")
 MARK_AS_ADVANCED(WITH_MYSQLD_LDFLAGS)
@@ -778,13 +726,6 @@ IF(WITH_MYSQLD_LDFLAGS)
   SET_TARGET_PROPERTIES(mysqld PROPERTIES LINK_FLAGS 
      "${MYSQLD_LINK_FLAGS} ${WITH_MYSQLD_LDFLAGS}")
 ENDIF()
-
-# See DEBUG_EXTNAME above: mysqld may already have name mysqld-debug,
-# and the rename is a no-op. If it is called 'mysqld' we rename it.
-INSTALL_DEBUG_TARGET(mysqld
-  DESTINATION ${INSTALL_SBINDIR}
-  RENAME mysqld-debug${CMAKE_EXECUTABLE_SUFFIX}
-)
 
 # Handle out-of-source build from source package with possibly broken 
 # bison. Copy bison output to from source to build directory, if not already 

--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -21,10 +21,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #ifndef xb0xb_h
 #define xb0xb_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 extern bool innodb_log_checksums_specified;
 extern bool innodb_checksum_algorithm_specified;
 
@@ -53,8 +49,21 @@ xb_compact_rebuild_indexes(void);
 void
 xb_fetch_tablespace_key(ulint space_id, byte *key, byte *iv);
 
-#ifdef __cplusplus
-}
-#endif
+/** Add file to tablespace map.
+@param[in]	file_name	file name
+@param[in]	tablespace_name	corresponding tablespace name */
+void
+xb_tablespace_map_add(const char *file_name, const char *tablespace_name);
+
+/** Delete tablespace from mapping.
+@param[in]	tablespace_name	tablespace name */
+void
+xb_tablespace_map_delete(const char *tablespace_name);
+
+/** Lookup backup file name for given file.
+@param[in]	file_name	file name
+@return		local file name */
+std::string
+xb_tablespace_backup_file_path(const std::string &file_name);
 
 #endif

--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -97,6 +97,7 @@ MYSQL_ADD_EXECUTABLE(xtrabackup
   backup_copy.cc
   keyring_plugins.cc
   kdf.cc
+  space_map.cc
   ${CMAKE_SOURCE_DIR}/sql-common/client_authentication.cc
   )
 

--- a/storage/innobase/xtrabackup/src/fil_cur.cc
+++ b/storage/innobase/xtrabackup/src/fil_cur.cc
@@ -50,15 +50,18 @@ and "./ibdata1" yield "ibdata1" in the output. */
 const char *
 xb_get_relative_path(
 /*=================*/
+	ulint		flags,		/*!< in: tablespace flags */
 	const char*	path,		/*!< in: tablespace path (either
 			  		relative or absolute) */
-	ibool		is_system)	/*!< in: TRUE for system tablespaces,
+	bool		is_system)	/*!< in: TRUE for system tablespaces,
 					i.e. when only the filename must be
 					returned. */
 {
 	const char *next;
 	const char *cur;
 	const char *prev;
+
+	bool is_shared = FSP_FLAGS_GET_SHARED(flags);
 
 	prev = NULL;
 	cur = path;
@@ -74,7 +77,7 @@ xb_get_relative_path(
 		return(cur);
 	} else {
 
-		return((prev == NULL) ? cur : prev);
+		return((prev == NULL || is_shared) ? cur : prev);
 	}
 
 }
@@ -112,7 +115,8 @@ xb_fil_cur_open(
 	tablespaces may have absolute paths for remote tablespaces in MySQL
 	5.6+. We want to make "local" copies for the backup. */
 	strncpy(cursor->rel_path,
-		xb_get_relative_path(cursor->abs_path, cursor->is_system),
+		xb_get_relative_path(node->space->flags, cursor->abs_path,
+				     cursor->is_system),
 		sizeof(cursor->rel_path));
 
 	/* In the backup mode we should already have a tablespace handle created

--- a/storage/innobase/xtrabackup/src/fil_cur.h
+++ b/storage/innobase/xtrabackup/src/fil_cur.h
@@ -127,9 +127,10 @@ and "./ibdata1" yield "ibdata1" in the output. */
 const char *
 xb_get_relative_path(
 /*=================*/
+	ulint		flags,		/*!< in: tablespace flags */
 	const char*	path,		/*!< in: tablespace path (either
 			  		relative or absolute) */
-	ibool		is_system);	/*!< in: TRUE for system tablespaces,
+	bool		is_system);	/*!< in: TRUE for system tablespaces,
 					i.e. when only the filename must be
 					returned. */
 

--- a/storage/innobase/xtrabackup/src/space_map.cc
+++ b/storage/innobase/xtrabackup/src/space_map.cc
@@ -1,0 +1,270 @@
+/******************************************************
+Copyright (c) 2018 Percona LLC and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+*******************************************************/
+
+#include <my_rapidjson_size_t.h>
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/writer.h>
+#include <rapidjson/stringbuffer.h>
+
+#include <fil0fil.h>
+
+#include <fstream>
+
+#include "space_map.h"
+#include "common.h"
+#include "xb0xb.h"
+
+Tablespace_map Tablespace_map::static_tablespace_map;
+
+const char *XBTS_FILE_NAME = "xtrabackup_tablespaces";
+const int XBTS_FILE_VERSION = 1;
+
+/** Add file to tablespace map.
+@param[in]  file_name file name
+@param[in]  tablespace_name corresponding tablespace name */
+void
+xb_tablespace_map_add(const char *file_name, const char *tablespace_name) {
+  Tablespace_map::instance().add(file_name, tablespace_name);
+}
+
+/** Delete tablespace mapping.
+@param[in]  tablespace_name tablespace name */
+void
+xb_tablespace_map_delete(const char *tablespace_name) {
+  Tablespace_map::instance().erase(tablespace_name);
+}
+
+/** Lookup backup file name for given file.
+@param[in]  file_name file name
+@return   local file name */
+std::string
+xb_tablespace_backup_file_path(const std::string &file_name) {
+  return Tablespace_map::instance().backup_file_name(file_name);
+}
+
+Tablespace_map &Tablespace_map::instance() {
+  return (static_tablespace_map);
+}
+
+/** Scan I_S.FILES for extended tablespaces.
+@param[in]  connection MySQL connection object */
+void Tablespace_map::scan(MYSQL *connection) {
+  const char *query = "SELECT FILE_NAME, TABLESPACE_NAME"
+                      "  FROM INFORMATION_SCHEMA.FILES"
+                      "  WHERE ENGINE = 'InnoDB'"
+                      "    AND STATUS = 'NORMAL'"
+                      "    AND FILE_TYPE <> 'TEMPORARY'"
+                      "    AND FILE_TYPE <> 'UNDO LOG'"
+                      "    AND FILE_ID <> 0";
+  MYSQL_RES *mysql_result;
+  MYSQL_ROW row;
+
+  mysql_result = xb_mysql_query(connection, query, true);
+
+  while ((row = mysql_fetch_row(mysql_result)) != nullptr) {
+    std::string file_name = row[0];
+    std::string tablespace_name = row[1];
+
+    add(file_name, tablespace_name);
+  }
+
+  mysql_free_result(mysql_result);
+}
+
+/** Add tablespace to the list.
+@param[in]  file_name tablespace file name
+@param[in]  tablespace_name tablespace name */
+void Tablespace_map::add(const std::string &file_name,
+                         const std::string &tablespace_name) {
+  char full_path[FN_REFLEN];
+
+  fn_format(full_path, file_name.c_str(), "", "", MY_RETURN_REAL_PATH);
+
+  if (!MySQL_datadir_path.is_ancestor(full_path)) {
+    space_by_file[full_path] = tablespace_name;
+    file_by_space[tablespace_name] = full_path;
+  }
+}
+
+/** Remove tablepsace from the list.
+@param[in]  tablespace_name tablespace name */
+void Tablespace_map::erase(const std::string &tablespace_name) {
+  auto i = space_by_file.find(tablespace_name);
+  if (i != space_by_file.end()) {
+    file_by_space.erase(i->second);
+    space_by_file.erase(i);
+  }
+}
+
+/** Return file name in the backup directory for given tablespace.
+@param[in]  file_name source tablespace file name */
+std::string Tablespace_map::backup_file_name(const std::string &file_name) const {
+  auto i = space_by_file.find(file_name);
+  if (i != space_by_file.end()) {
+    return ("./" + i->second + ".ibd");
+  }
+
+  return (file_name);
+}
+
+/** Return original file name for given tablespace.
+@param[in]  space_name source tablespace name */
+std::string Tablespace_map::external_file_name(
+  const std::string &space_name) const {
+  auto i = file_by_space.find(space_name);
+  if (i != file_by_space.end()) {
+    return (i->second);
+  }
+
+  return std::string();
+}
+
+/** Return the list of external tablespaces. */
+Tablespace_map::vector_t Tablespace_map::external_files() const {
+  Tablespace_map::vector_t result;
+  for (auto i : space_by_file) {
+    result.push_back(i.first);
+  }
+  return (result);
+}
+
+/** Serialize talespace list into the current directory. */
+bool Tablespace_map::serialize() const {
+  using rapidjson::StringBuffer;
+
+  StringBuffer buf;
+
+  bool rc = serialize(buf);
+  if (!rc) {
+    return (rc);
+  }
+
+  const char *path = XBTS_FILE_NAME;
+  std::ofstream f(path);
+
+  f.write(buf.GetString(), buf.GetSize());
+  f.close();
+
+  return (rc);
+}
+
+/** Serialize talespace list into datasink.
+@param[in]  ds datasink */
+bool Tablespace_map::serialize(ds_ctxt_t *ds) const {
+  using rapidjson::StringBuffer;
+
+  StringBuffer buf;
+
+  bool rc = serialize(buf);
+  if (!rc) {
+    return (rc);
+  }
+
+  MY_STAT mystat;
+  mystat.st_size = buf.GetSize();
+  mystat.st_mtime = my_time(0);
+
+  const char *path = XBTS_FILE_NAME;
+  ds_file_t *stream = ds_open(ds, path, &mystat);
+  if (stream == NULL) {
+    msg("xtrabackup: Error: cannot open output stream for %s\n", path);
+    return (false);
+  }
+
+  rc = true;
+
+  if (ds_write(stream, buf.GetString(), buf.GetSize())) {
+    rc = false;
+  }
+
+  if (ds_close(stream)) {
+    rc = false;
+  }
+
+  return (rc);
+}
+
+/** Serialize talespace list into a buffer.
+@param[out]  buf output buffer */
+bool Tablespace_map::serialize(rapidjson::StringBuffer &buf) const {
+  using Writer = rapidjson::Writer<rapidjson::StringBuffer>;
+
+  Writer writer(buf);
+
+  writer.StartObject();
+  writer.String("version");
+  writer.Int(XBTS_FILE_VERSION);
+
+  writer.String("external_tablespaces");
+  writer.StartArray();
+
+  for (auto const& file : space_by_file) {
+    writer.StartObject();
+    writer.String("file_name");
+    writer.String(file.first.c_str(), file.first.length());
+    writer.String("tablespace_name");
+    writer.String(file.second.c_str(), file.second.length());
+    writer.EndObject();
+  }
+  writer.EndArray();
+
+  writer.EndObject();
+
+  return (true);
+}
+
+bool Tablespace_map::deserialize(const std::string &dir) {
+  using rapidjson::Document;
+  using rapidjson::IStreamWrapper;
+
+  const std::string path = dir + XBTS_FILE_NAME;
+  std::ifstream f(path);
+
+  if (f.fail()) {
+    msg("xtrabackup: Error: cannot open file '%s'" , path.c_str());
+    return (false);
+  }
+
+  IStreamWrapper wrapper(f);
+
+  Document doc;
+  doc.ParseStream(wrapper);
+  if (doc.HasParseError()) {
+    msg("xtrabackup: JSON parse error in file '%s'\n", path.c_str());
+    return (false);
+  }
+
+  auto root = doc.GetObject();
+
+  int version = root["version"].GetInt();
+  if (version > XBTS_FILE_VERSION) {
+    msg("xtrabackup: Error: wrong '%s' file version %d, maximum version"
+        "supported is %d", XBTS_FILE_NAME, version, XBTS_FILE_VERSION);
+    return (false);
+  }
+
+  auto list = root["external_tablespaces"].GetArray();
+
+  for (auto &entry : list) {
+    const auto &object = entry.GetObject();
+    add(object["file_name"].GetString(), object["tablespace_name"].GetString());
+  }
+
+  return (true);
+}

--- a/storage/innobase/xtrabackup/src/space_map.h
+++ b/storage/innobase/xtrabackup/src/space_map.h
@@ -1,0 +1,89 @@
+/******************************************************
+Copyright (c) 2018 Percona LLC and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+*******************************************************/
+
+#ifndef XTRABACKUP_SPACE_MAP_H
+#define XTRABACKUP_SPACE_MAP_H
+
+#include <map>
+#include <vector>
+#include <string>
+#include <rapidjson/fwd.h>
+
+#include "datasink.h"
+#include "backup_mysql.h"
+
+/* Tablespace to file name mapping */
+class Tablespace_map {
+public:
+  typedef std::map<std::string, std::string> map_t;
+  typedef std::vector<std::string> vector_t;
+
+private:
+  map_t file_by_space;
+  map_t space_by_file;
+
+  /** Serialize talespace list into a buffer.
+  @param[out]  buf output buffer */
+  bool serialize(rapidjson::StringBuffer &buf) const;
+
+  Tablespace_map() { };
+
+  static Tablespace_map static_tablespace_map;
+
+public:
+
+  /** Scan I_S.FILES for extended tablespaces.
+  @param[in]  connection MySQL connection object */
+  void scan(MYSQL *connection);
+
+  /** Serialize talespace list into datasink.
+  @param[in]  ds datasink */
+  bool serialize(ds_ctxt_t *ds) const;
+
+  /** Serialize talespace list into the current directory. */
+  bool serialize() const;
+
+  /** Deserialize talespace list from given directory.
+  @param[in]  dir directory to read file from */
+  bool deserialize(const std::string &dir);
+
+  /** Add tablespace to the list.
+  @param[in]  file_name tablespace file name
+  @param[in]  tablespace_name tablespace name */
+  void add(const std::string &file_name, const std::string &tablespace_name);
+
+  /** Remove tablepsace from the list.
+  @param[in]  tablespace_name tablespace name */
+  void erase(const std::string &tablespace_name);
+
+  /** Return file name in the backup directory for given tablespace.
+  @param[in]  file_name source tablespace file name */
+  std::string backup_file_name(const std::string &file_name) const;
+
+  /** Return original file name for given tablespace.
+  @param[in]  space_name source tablespace name */
+  std::string external_file_name(const std::string &space_name) const;
+
+  /** Return the list of external tablespaces. */
+  vector_t external_files() const;
+
+  /** Return the list of external tablespaces. */
+  static Tablespace_map &instance();
+};
+
+#endif /* XTRABACKUP_SPACE_MAP_H */

--- a/storage/innobase/xtrabackup/test/t/remote_tablespaces.sh
+++ b/storage/innobase/xtrabackup/test/t/remote_tablespaces.sh
@@ -32,9 +32,9 @@ do
 EOF
 done
 
-checksum_a=`checksum_table test t`
-
 xtrabackup --backup --target-dir=$topdir/backup
+
+record_db_state test
 
 stop_server
 
@@ -66,16 +66,7 @@ for cmd in "--copy-back" "--move-back" ; do
 
     start_server
 
-    checksum_b=`checksum_table test t`
-
-    vlog "Old checksum: $checksum_a"
-    vlog "New checksum: $checksum_b"
-
-    if [ "$checksum_a" != "$checksum_b"  ]
-    then
-        vlog "Checksums do not match"
-        exit -1
-    fi
+    verify_db_state test
 
     stop_server
 


### PR DESCRIPTION
1. Query I_S.FILES to locate all remote tablespaces and build file
to tablespace mapping when starting a backup
2. Serialize/deserialize the list of remote tablespaces in JSON format
and store it in backup directory
3. Update tablespace mappings when replaying redo logs
4. Make copy-back to use tablespace mappings