### PR TITLE
Handling different compression types in bootstrap.

### DIFF
--- a/storage/innobase/xtrabackup/test/bootstrap.sh
+++ b/storage/innobase/xtrabackup/test/bootstrap.sh
@@ -135,7 +135,7 @@ then
 fi
 
 echo "Unpacking $tarball into $destdir"
-tar zxf $tarball -C $destdir
+tar xf $tarball -C $destdir
 sourcedir="$destdir/`ls $destdir`"
 if test -n "$sourcedir"
 then


### PR DESCRIPTION
Starting with 8.0.12, mysql server is distributed as tar.xz.
This change handles both xz and gz.